### PR TITLE
Fixed Issue #490: hsexpo.py selects wrong HS

### DIFF
--- a/Scripts/Structure/hsexpo
+++ b/Scripts/Structure/hsexpo
@@ -76,9 +76,9 @@ elif options.exp[0] == "H" and options.exp[3] == "B":
     hse = HSExposureCB(m, RADIUS)
     #hse.write_pymol_script()
     if options.exp[-1] == "D":
-        k = 'EXP_HSE_B_U'
-    else:
         k = 'EXP_HSE_B_D'
+    else:
+        k = 'EXP_HSE_B_U'
 elif options.exp == "CN":
     hse = ExposureCN(m, RADIUS)
     k = 'EXP_CN'


### PR DESCRIPTION
Options "D" and "U" now select the correct "Down" and "Up" half spheres (a typo in IF-ELSE loop was fixed).
